### PR TITLE
source version update and formatting cleanup

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'quickbooks'
-version: '0.1.0'
+version: '0.1.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 

--- a/models/double_entry_transactions/int_quickbooks__credit_memo_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__credit_memo_double_entry.sql
@@ -67,7 +67,6 @@ final as (
         transaction_id,
         transaction_date,
         amount * -1 as amount,
-        --amount as amount,
         df_accounts.account_id,
         'debit' as transaction_type,
         'credit_memo' as transaction_source

--- a/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
@@ -112,7 +112,7 @@ invoice_join as (
     where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id, bundle_income_accounts.account_id) is not null         
 
     {% else %}
-        where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id) is not null 
+    where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id) is not null 
 
     {% endif %}
 ),

--- a/models/transaction_lines/int_quickbooks__invoice_transactions.sql
+++ b/models/transaction_lines/int_quickbooks__invoice_transactions.sql
@@ -27,7 +27,7 @@ final as (
         coalesce(invoice_lines.quantity, invoice_lines.sales_item_quantity) as item_quantity,
         invoice_lines.sales_item_unit_price as item_unit_price,
         case when invoice_lines.item_id is null
-            then coalesce(items.income_account_id, items.asset_account_id, items.expense_account_id)
+            then coalesce(items.income_account_id, items.expense_account_id, items.asset_account_id)
             else invoice_lines.account_id
                 end as account_id,
         coalesce(invoice_lines.discount_class_id, invoice_lines.sales_item_class_id) as class_id,

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fivetran/quickbooks_source
-    version: 0.1.0
+    version: 0.1.1


### PR DESCRIPTION
The minor changes in this branch consist of:
- Updating the project version from v0.1.0 -> v0.1.1.
- Removing an unnecessary comment within the `int_quickbooks__credit_memo_double_entry` model.
- Correcting an indented where clause within the `int_quickbooks__invoice_double_entry` model.
- Fixing the `account_id` coalesce within the `int_quickbooks__invoice_transactions` model to appropriately search the expense account before the asset account reference for an invoice.
- Updating the quickbooks_source package reference from v0.1.0 -> v0.1.1.