### PR TITLE
Sales receipt var

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ vars:
     using_refund_receipt: false         #disable if you don't have refund receipts in Quickbooks
     using_transfer:       false         #disable if you don't have transfers in Quickbooks
     using_vendor_credit:  false         #disable if you don't have vendor credits in Quickbooks
+    using_sales_receipt:  false         #disable if you don't have sales receipts in QuickBooks
 
   quickbooks_source:
     using_bill:           false         #disable if you don't have bils or bill payments in Quickbooks
@@ -79,6 +80,7 @@ vars:
     using_refund_receipt: false         #disable if you don't have refund receipts in Quickbooks
     using_transfer:       false         #disable if you don't have transfers in Quickbooks
     using_vendor_credit:  false         #disable if you don't have vendor credits in Quickbooks
+    using_sales_receipt:  false         #disable if you don't have sales receipts in QuickBooks
 ```
 
 ## Analysis

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ vars:
 
 ### Disabling models
 
-This package takes into consideration that not every QuickBooks account utilizes the same transactional tables, and allows you to disable the corresponding functionality. By default, all variables are assumed to be `true`.  Add variables for only the tables you would like to disable: 
+This package takes into consideration that not every QuickBooks account utilizes the same transactional tables, and allows you to disable the corresponding functionality. By default, most variables' values are assumed to be `true` (with exception of purchase orders). Add variables for only the tables you want to disable or enable respectively:
 
 ```yml
 # dbt_project.yml
@@ -81,6 +81,7 @@ vars:
     using_transfer:       false         #disable if you don't have transfers in Quickbooks
     using_vendor_credit:  false         #disable if you don't have vendor credits in Quickbooks
     using_sales_receipt:  false         #disable if you don't have sales receipts in QuickBooks
+    using_purchase_order: true          #enable if you want to include purchase orders in your staging models
 ```
 
 ## Analysis

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'quickbooks'
-version: '0.1.1'
+version: '0.1.2'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 
@@ -67,6 +67,7 @@ vars:
     using_refund_receipt: True
     using_transfer:       True
     using_vendor_credit:  True
+    using_sales_receipt:  True
 
 analysis-paths: ["analysis"]
 

--- a/models/double_entry_transactions/int_quickbooks__sales_receipt_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__sales_receipt_double_entry.sql
@@ -1,6 +1,10 @@
 /*
 Table that creates a debit record to the specified cash account and a credit record to the specified asset account.
 */
+
+--To disable this model, set the using_sales_receipt variable within your dbt_project.yml file to False.
+{{ config(enabled=var('using_sales_receipt', True)) }}
+
 with sales_receipts as (
     select *
     from {{ref('stg_quickbooks__sales_receipt')}}

--- a/models/intermediate/int_quickbooks__invoice_join.sql
+++ b/models/intermediate/int_quickbooks__invoice_join.sql
@@ -85,6 +85,11 @@ final as (
         {% if var('using_estimate', True) %}
         coalesce(estimates.total_amount, 0) as estimate_total_amount,
         estimates.transaction_status as estimate_status,
+
+        {% else %}
+        cast(null as decimal) as estimate_total_amount,
+        cast(null as {{ dbt_utils.type_string() }}) as estimate_status,
+
         {% endif %}
 
         invoice_link.due_date as due_date,
@@ -105,16 +110,8 @@ final as (
     left join payment_lines_payment
         on payments.payment_id = payment_lines_payment.payment_id
             and invoice_link.invoice_id = payment_lines_payment.invoice_id
-    
-    {% if var('using_estimate', True) %}
+
     group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
-
-    {% else %}
-
-    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
-
-    {% endif %}
-
 )
 
 select * 

--- a/models/intermediate/int_quickbooks__sales_union.sql
+++ b/models/intermediate/int_quickbooks__sales_union.sql
@@ -1,12 +1,24 @@
+{{ config(enabled=fivetran_utils.enabled_vars_one_true(['using_sales_receipt','using_invoice'])) }}
+
 with sales_union as (
+    {% if var('using_sales_receipt', True) %}
     select *
     from {{ ref('int_quickbooks__sales_receipt_transactions') }}
+    {% endif %}
 
-    {% if var('using_invoice', True) %}
+    {% if fivetran_utils.enabled_vars(['using_sales_receipt','using_invoice']) %}
     union all
 
     select *
     from {{ ref('int_quickbooks__invoice_transactions') }}
+
+    {% else %}
+
+        {% if var('using_invoice', True) %}
+        select *
+        from {{ ref('int_quickbooks__invoice_transactions') }}
+        {% endif %}   
+        
     {% endif %}
 
     {% if var('using_refund_receipt', True) %}

--- a/models/quickbooks__expenses_sales_enhanced.sql
+++ b/models/quickbooks__expenses_sales_enhanced.sql
@@ -3,7 +3,7 @@ with expenses as (
     from {{ ref('int_quickbooks__expenses_union') }}
 ),
 
-{% if var('using_invoice', True) %}
+{% if fivetran_utils.enabled_vars_one_true(['using_sales_receipt','using_invoice']) %}
 sales as (
     select *
     from {{ ref('int_quickbooks__sales_union') }}
@@ -14,7 +14,7 @@ final as (
     select *
     from expenses
 
-    {% if var('using_invoice', True) %}
+    {% if fivetran_utils.enabled_vars_one_true(['using_sales_receipt','using_invoice']) %}
     union all
 
     select *

--- a/models/quickbooks__general_ledger.sql
+++ b/models/quickbooks__general_ledger.sql
@@ -8,10 +8,12 @@ with gl_union as (
         transaction_source
     from {{ref('int_quickbooks__purchase_double_entry')}}
 
+    {% if var('using_sales_receipt', True) %}
     union all
 
     select *
     from {{ref('int_quickbooks__sales_receipt_double_entry')}}
+    {% endif %}
 
     {% if var('using_bill', True) %}
     union all

--- a/models/transaction_lines/int_quickbooks__invoice_transactions.sql
+++ b/models/transaction_lines/int_quickbooks__invoice_transactions.sql
@@ -26,7 +26,7 @@ final as (
         coalesce(invoice_lines.sales_item_item_id, invoice_lines.item_id) as item_id,
         coalesce(invoice_lines.quantity, invoice_lines.sales_item_quantity) as item_quantity,
         invoice_lines.sales_item_unit_price as item_unit_price,
-        case when invoice_lines.item_id is null
+        case when invoice_lines.account_id is null
             then coalesce(items.income_account_id, items.expense_account_id, items.asset_account_id)
             else invoice_lines.account_id
                 end as account_id,
@@ -44,7 +44,7 @@ final as (
         on invoices.invoice_id = invoice_lines.invoice_id
 
     left join items
-        on invoice_lines.sales_item_item_id = items.item_id
+        on coalesce(invoice_lines.sales_item_item_id, invoice_lines.item_id) = items.item_id
 )
 
 select *

--- a/models/transaction_lines/int_quickbooks__purchase_transactions.sql
+++ b/models/transaction_lines/int_quickbooks__purchase_transactions.sql
@@ -6,6 +6,11 @@ with purchases as (
     from {{ ref('stg_quickbooks__purchase') }}
 ),
 
+items as (
+    select *
+    from {{ref('stg_quickbooks__item')}}
+),
+
 purchase_lines as (
     select *
     from {{ ref('stg_quickbooks__purchase_line') }}
@@ -18,10 +23,10 @@ final as (
         purchases.doc_number,
         'purchase' as transaction_type,
         purchases.transaction_date,
-        purchase_lines.account_expense_account_id as account_id,
+        coalesce(purchase_lines.account_expense_account_id, items.expense_account_id) as account_id,
         purchase_lines.account_expense_class_id as class_id,
         purchases.department_id,
-        purchases.customer_id,
+        coalesce(purchases.customer_id, account_expense_customer_id, item_expense_customer_id) as customer_id,
         purchases.vendor_id,
         coalesce(purchase_lines.account_expense_billable_status, purchase_lines.item_expense_billable_status) as billable_status,
         purchase_lines.description,
@@ -31,6 +36,9 @@ final as (
 
     inner join purchase_lines 
         on purchases.purchase_id = purchase_lines.purchase_id
+
+    left join items
+        on purchase_lines.item_expense_item_id = items.item_id
 )
 
 select *

--- a/models/transaction_lines/int_quickbooks__refund_receipt_transactions.sql
+++ b/models/transaction_lines/int_quickbooks__refund_receipt_transactions.sql
@@ -43,7 +43,7 @@ final as (
     inner join refund_receipt_lines
         on refund_receipts.refund_id = refund_receipt_lines.refund_id
 
-     left join items
+    left join items
         on refund_receipt_lines.sales_item_item_id = items.item_id
 )
 

--- a/models/transaction_lines/int_quickbooks__vendor_credit_transactions.sql
+++ b/models/transaction_lines/int_quickbooks__vendor_credit_transactions.sql
@@ -24,7 +24,7 @@ final as (
         'vendor_credit' as transaction_type,
         vendor_credits.transaction_date,
         case when vendor_credit_lines.account_expense_account_id is null
-            then items.asset_account_id
+            then items.expense_account_id
             else vendor_credit_lines.account_expense_account_id
                 end as account_id,
         coalesce(vendor_credit_lines.account_expense_class_id, vendor_credit_lines.item_expense_class_id) as class_id,

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
   # - package: fivetran/quickbooks_source
-  #   version: 0.1.1
+  #   version: 0.1.2
     - git: https://github.com/fivetran/dbt_quickbooks_source.git
       revision: sales_receipt_var
       warn-unpinned: false

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,6 @@
 packages:
-  - package: fivetran/quickbooks_source
-    version: 0.1.1
+  # - package: fivetran/quickbooks_source
+  #   version: 0.1.1
+    - git: https://github.com/fivetran/dbt_quickbooks_source.git
+      revision: sales_receipt_var
+      warn-unpinned: false

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,3 @@
 packages:
-  # - package: fivetran/quickbooks_source
-  #   version: 0.1.2
-    - git: https://github.com/fivetran/dbt_quickbooks_source.git
-      revision: sales_receipt_var
-      warn-unpinned: false
+  - package: fivetran/quickbooks_source
+    version: 0.1.2


### PR DESCRIPTION
Changes in this branch include:

- Addition of the `using_sales_receipt` variable within the sales receipt [doulbe_entry_transaction](https://github.com/fivetran/dbt_quickbooks/compare/sales_receipt_var?expand=1#diff-148e1142c81fa7f76750343d47efcbd307d914ea788773097c184a939b320dbd), [sales_union](https://github.com/fivetran/dbt_quickbooks/compare/sales_receipt_var?expand=1#diff-093304d8185b50b927b1559842aad6a4dc29f318f6ea96e07d80158b6dada200), [expenses_sales_enhanced](https://github.com/fivetran/dbt_quickbooks/compare/sales_receipt_var?expand=1#diff-ca525231e5a9f9d23b077ecd44d435d0fea808e8348c2595516402b1636538c5), and [general ledger](https://github.com/fivetran/dbt_quickbooks/compare/sales_receipt_var?expand=1#diff-b9da735ae74375807d38663eff49ded18305432673b81dcb6d40f248693dca16) models.
- Inclusion of the `enabled_vars_one_true` macro in the [int_quickbooks__sales_union](https://github.com/fivetran/dbt_quickbooks/compare/sales_receipt_var?expand=1#diff-093304d8185b50b927b1559842aad6a4dc29f318f6ea96e07d80158b6dada200) model where the model will still run if at least one variable is true for `sales receipt` and `invoice`. Otherwise the model will not run.
- James Ayoub recommended changes to capture all customer and account id's within the transaction_line models for `bills`, `invoices`, `purchases`, and `vendor credits`.
- Minor format change within `refund receipt` transaction lines model.
- Temporary source package reference. Once the [PR](https://github.com/fivetran/dbt_quickbooks_source/pull/7) for the quickbooks source package has been approved this will be updated to the proper source version.

[Joe PR Loom Description](https://www.loom.com/share/7ec2459903834725a2b5f677b76024d3)