### PR TITLE
account inactive fix

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,20 +1,20 @@
 config-version: 2
 
 name: 'quickbooks'
-version: '0.2.0'
+version: '0.2.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 
 models:
   quickbooks:
-    materialized: table
+    +materialized: table
     +schema: quickbooks
     double_entry_transactions:
-      materialized: ephemeral
+      +materialized: ephemeral
     transaction_lines:
-      materialized: ephemeral
+      +materialized: ephemeral
     intermediate:
-      materialized: ephemeral
+      +materialized: ephemeral
 
 vars:
   quickbooks:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,22 +1,22 @@
 name: 'quickbooks_integration_tests'
-version: '0.2.0'
+version: '0.2.1'
 profile: 'integration_tests'
 config-version: 2
 
 models: 
   quickbooks:
-    materialized: table
+    +materialized: table
     double_entry_transactions:
-      materialized: table
+      +materialized: table
     transaction_lines:
-      materialized: table
+      +materialized: table
     intermediate:
-      materialized: table
+      +materialized: table
 
   quickbooks_source:
-    materialized: table
+    +materialized: table
     tmp:
-      materialized: view
+      +materialized: view
 
 vars:
   quickbooks:

--- a/models/double_entry_transactions/int_quickbooks__bill_payment_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__bill_payment_double_entry.sql
@@ -26,6 +26,7 @@ ap_accounts as (
     from accounts
     
     where account_type = 'Accounts Payable'
+        and is_active
 ),
 
 bill_payment_join as (

--- a/models/double_entry_transactions/int_quickbooks__credit_memo_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__credit_memo_double_entry.sql
@@ -27,10 +27,11 @@ accounts as (
 
 df_accounts as (
     select
-        max(account_id) as account_id
+        account_id as account_id
     from accounts
 
     where account_type = 'Accounts Receivable'
+        and is_active
 ),
 
 credit_memo_join as (

--- a/models/double_entry_transactions/int_quickbooks__deposit_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__deposit_double_entry.sql
@@ -27,6 +27,7 @@ uf_accounts as (
     from accounts
 
     where account_sub_type = 'UndepositedFunds'
+        and is_active
 ),
 
 deposit_join as (

--- a/models/double_entry_transactions/int_quickbooks__payment_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__payment_double_entry.sql
@@ -26,6 +26,7 @@ ar_accounts as (
     from accounts
 
     where account_type = 'Accounts Receivable'
+        and is_active
 ),
 
 payment_join as (

--- a/models/double_entry_transactions/int_quickbooks__refund_receipt_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__refund_receipt_double_entry.sql
@@ -25,11 +25,6 @@ items as (
         on item.parent_item_id = parent.item_id
 ),
 
-accounts as (
-    select *
-    from {{ ref('stg_quickbooks__account') }}
-),
-
 refund_receipt_join as (
     select
         refund_receipts.refund_id as transaction_id,

--- a/models/double_entry_transactions/int_quickbooks__sales_receipt_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__sales_receipt_double_entry.sql
@@ -25,11 +25,6 @@ items as (
         on item.parent_item_id = parent.item_id
 ),
 
-accounts as (
-    select *
-    from {{ ref('stg_quickbooks__account') }}
-),
-
 sales_receipt_join as (
     select
         sales_receipts.sales_receipt_id as transaction_id,


### PR DESCRIPTION
This PR includes the following updates:

- Addresses Issue #8 by selecting only active accounts receivable accounts to be used when generating the offsetting entry for credit memo transactions.
- Removes unnecessary account declarations within models that do not require the accounts model.
- Package upgrade to v0.2.1