### PR TITLE
Add invoice discount to invoice_double_entry [resolve #59]

### DIFF
--- a/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
+++ b/models/double_entry_transactions/int_quickbooks__invoice_double_entry.sql
@@ -79,15 +79,15 @@ ar_accounts as (
     where account_type = 'Accounts Receivable'
 ),
 
-invoice_join as (
+invoice_lines_without_discount as (
     select
-        invoices.invoice_id as transaction_id,
-        invoice_lines.index, 
-        invoices.transaction_date as transaction_date,
-        case when invoices.total_amount != 0
-            then invoice_lines.amount
-            else invoices.total_amount
-                end as amount,
+	    invoices.invoice_id as transaction_id,
+	    invoice_lines.index,
+	    invoices.transaction_date as transaction_date,
+	    case when invoices.total_amount != 0
+	        then invoice_lines.amount
+	        else invoices.total_amount
+	            end as amount,
 
         {% if var('using_invoice_bundle', True) %}
         coalesce(invoice_lines.account_id, items.parent_income_account_id, items.income_account_id, bundle_income_accounts.account_id) as account_id,
@@ -96,26 +96,64 @@ invoice_join as (
         coalesce(invoice_lines.account_id, items.income_account_id) as account_id,
 
         {% endif %}
-        invoices.customer_id
+	    invoices.customer_id
 
-    from invoices
+	from invoices
 
-    inner join invoice_lines
-        on invoices.invoice_id = invoice_lines.invoice_id
+	inner join invoice_lines
+	    on invoices.invoice_id = invoice_lines.invoice_id
 
-    left join items
-        on coalesce(invoice_lines.sales_item_item_id, invoice_lines.item_id) = items.item_id
+	left join items
+	    on coalesce(invoice_lines.sales_item_item_id, invoice_lines.item_id) = items.item_id
 
     {% if var('using_invoice_bundle', True) %}
     left join bundle_income_accounts
         on bundle_income_accounts.bundle_id = invoice_lines.bundle_id
 
-    where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id, bundle_income_accounts.account_id) is not null         
+    where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id, bundle_income_accounts.account_id) is not null
 
     {% else %}
-    where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id) is not null 
+    where coalesce(invoice_lines.account_id, invoice_lines.sales_item_account_id, invoice_lines.sales_item_item_id, invoice_lines.item_id) is not null
 
     {% endif %}
+),
+
+invoice_discount as (
+    select
+	    invoices.invoice_id as transaction_id,
+	    invoices.transaction_date as transaction_date,
+	    case when invoices.total_amount != 0
+	        then invoice_lines.amount
+	        else invoices.total_amount
+	            end as amount,
+
+	    invoice_lines.discount_account_id as account_id,
+
+	    invoices.customer_id
+
+    from invoices
+
+    inner join invoice_lines
+	    on invoices.invoice_id = invoice_lines.invoice_id
+
+    left join items
+	    on coalesce(invoice_lines.sales_item_item_id, invoice_lines.item_id) = items.item_id
+    WHERE
+        invoice_lines.discount_account_id is not null
+),
+
+ar_line_item as (
+    select distinct
+        iwd.transaction_id,
+        iwd.transaction_date,
+        ar_accounts.account_id,
+        ar_accounts.name,
+        iwd.customer_id,
+        sum(iwd.amount) over (partition by iwd.transaction_id) - coalesce(invoice_discount.amount, 0) as amount
+    from invoice_lines_without_discount iwd
+    left join invoice_discount on iwd.transaction_id = invoice_discount.transaction_id
+    cross join ar_accounts
+    order by transaction_date
 ),
 
 final as (
@@ -126,27 +164,57 @@ final as (
         customer_id,
         cast(null as {{ dbt_utils.type_string() }}) as vendor_id,
         amount,
-        account_id,
+        amount as amount_adj,
+        iwd.account_id,
         'credit' as transaction_type,
         'invoice' as transaction_source
-    from invoice_join
+    from invoice_lines_without_discount iwd
+    left join {{ref('stg_quickbooks__account')}} sqa on iwd.account_id = sqa.account_id
 
     union all
 
     select
         transaction_id,
-        index,
+        cast(null as {{ dbt_utils.type_string() }}) as index,
         transaction_date,
         customer_id,
         cast(null as {{ dbt_utils.type_string() }}) as vendor_id,
         amount,
-        ar_accounts.account_id,
+        amount * -1 as amount_adj,
+        account_id,
         'debit' as transaction_type,
         'invoice' as transaction_source
-    from invoice_join
+    from ar_line_item
 
-    cross join ar_accounts
+    union all
+
+    select
+        transaction_id,
+        cast(null as {{ dbt_utils.type_string() }}) as index,
+        transaction_date,
+        customer_id,
+        cast(null as {{ dbt_utils.type_string() }}) as vendor_id,
+        amount,
+        amount * -1 as amount_adj,
+        invoice_discount.account_id,
+        'debit' as transaction_type,
+        'invoice' as transaction_source
+    from invoice_discount
+    left join {{ref('stg_quickbooks__account')}} sqa on invoice_discount.account_id = sqa.account_id
 )
 
-select * 
+select
+    transaction_id,
+    row_number() over (partition by transaction_id order by index nulls last) - 1 as index,
+    transaction_date,
+    customer_id,
+    vendor_id,
+    amount,
+    account_id,
+    transaction_type,
+    transaction_source
 from final
+order by
+    transaction_date,
+    transaction_id,
+    index nulls last


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Yes. James Heller from Apartment 304.

**What change(s) does this PR introduce?** 
This change adds invoice discounts to the `int_quickbooks__invoice_double_entry` table, and calculates the expected Accounts Receivable amount (sum of sales/service line items less discount), instead of creating an A/R record for each sales/service line item in the invoice.

**Did you update the CHANGELOG?** 
- [ ] Yes

Not yet. I would like to review the changes with the team.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

This change will generate correct invoice amounts for users using invoice discounts.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

Not yet. I would like to review the changes with the team.

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature [#59]
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Local (please provide additional testing details below)
- [x] Fivetran

I tested the feature using a Fivetran Transformation on a Databricks destination. I'm happy to take on further testing and validation if the team thinks the query changes can be merged in.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [x] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:smiley:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
