### PR TITLE
Fix for date parsing when data is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_quickbooks v0.12.1
+[PR #108](https://github.com/fivetran/dbt_quickbooks/pull/108)
+
 # dbt_quickbooks v0.12.0
 [PR #103](https://github.com/fivetran/dbt_quickbooks/pull/103/files) includes the following updates:
 ## 🚘 Under the Hood

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 name: 'quickbooks'
 
-version: '0.12.0'
+version: '0.12.1'
 
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -72,8 +72,8 @@ with spine as (
     {% else %}
         {{ dbt_utils.date_spine(
             datepart="month",
-            start_date="'2000-01-01'",
-            end_date="'2000-01-01'"
+            start_date="cast('2000-01-01' as date)",
+            end_date="cast('2000-01-01' as date)"
             )
         }}
     {% endif %}

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -18,10 +18,10 @@ with spine as (
 
         {% endif %}
     {% else %}
-        {% set first_date_adjust = "'2001-01-01'" %}
+        {% set first_date_adjust = "cast('2000-01-01' as date)" %}
     {% endif %}        
 
-    {% else %} {% set first_date_adjust = "'2001-01-01'" %}
+    {% else %} {% set first_date_adjust = "cast('2001-01-01' as date)" %}
     {% endif %}
 
     {% if execute %}

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -1,53 +1,81 @@
 -- depends_on: {{ ref('quickbooks__general_ledger') }}
-
 with spine as (
+
     {% if execute %}
     {% set first_date_query %}
-        select min(transaction_date) as min_date from {{ ref('quickbooks__general_ledger') }}
+        select  min( transaction_date ) as min_date from {{ ref('quickbooks__general_ledger') }}
     {% endset %}
+
     {% set first_date_result = run_query(first_date_query) %}
     {% if first_date_result and first_date_result.columns[0][0] %}
         {% set first_date = first_date_result.columns[0][0]|string %}
+
         {% if target.type == 'postgres' %}
             {% set first_date_adjust = "cast('" ~ first_date[0:10] ~ "' as date)" %}
+
         {% else %}
             {% set first_date_adjust = "'" ~ first_date[0:10] ~ "'" %}
+
         {% endif %}
     {% else %}
-        {% set first_date_adjust = "null" %}
+        {% set first_date_adjust = "'2000-01-01'" %}
+    {% endif %}        
+
+    {% else %} {% set first_date_adjust = "'2000-01-01'" %}
     {% endif %}
 
+    {% if execute %}
     {% set last_date_query %}
-        select max(transaction_date) as max_date from {{ ref('quickbooks__general_ledger') }}
+        select  max( transaction_date ) as max_date from {{ ref('quickbooks__general_ledger') }}
     {% endset %}
-    {% set last_date_result = run_query(last_date_query) %}
-    {% if last_date_result and last_date_result.columns[0][0] %}
-        {% set last_date = last_date_result.columns[0][0]|string %}
-        {% set current_date_query %}
-            select current_date
-        {% endset %}
-        {% set current_date = run_query(current_date_query).columns[0][0]|string %}
-        {% if current_date < last_date %}
-            {% set last_date_adjust = last_date %}
+
+    {% set current_date_query %}
+        select current_date
+    {% endset %}
+
+    {% if run_query(current_date_query).columns[0][0]|string < run_query(last_date_query).columns[0][0]|string %}
+        {% set last_date_result = run_query(current_date_query) %}
+        {% if last_date_result and last_date_result.columns[0][0] %}
+            {% set last_date = last_date_result.columns[0][0]|string %}
         {% else %}
-            {% set last_date_adjust = current_date %}
-        {% endif %}
-        {% if target.type == 'postgres' %}
-            {% set last_date_adjust = "cast('" ~ last_date_adjust[0:10] ~ "' as date)" %}
-        {% else %}
-            {% set last_date_adjust = "'" ~ last_date_adjust[0:10] ~ "'" %}
+            {% set last_date = "'2000-01-01'" %}
         {% endif %}
     {% else %}
-        {% set last_date_adjust = "null" %}
+        {% set last_date_result = run_query(current_date_query) %}
+        {% if last_date_result and last_date_result.columns[0][0] %}
+            {% set last_date = last_date_result.columns[0][0]|string %}
+        {% else %}
+            {% set last_date = "'2000-01-01'" %}
+        {% endif %}
+    {% endif %}
+        
+    {% if target.type == 'postgres' %}
+        {% if last_date !="null" && last_date != "None" %}
+            {% set last_date_adjust = "cast('" ~ last_date[0:10] ~ "' as date)" %}
+        {% else %}
+            {% set last_date_adjust = "cast('2000-01-01' as date)" %}
+        {% endif %}
+
+    {% else %}
+        {% set last_date_adjust = "'" ~ last_date[0:10] ~ "'" %}
+
     {% endif %}
     {% endif %}
 
-    {% if first_date_adjust != "null" and last_date_adjust != "null" %}
-    {{ dbt_utils.date_spine(
-        datepart="month",
-        start_date=first_date_adjust,
-        end_date=dbt.dateadd("month", 1, last_date_adjust)
-    ) }}
+    {% if first_date_adjust !="null" && first_date_adjust!="None" and last_date_adjust !="null" and last_date_adjust!="None" %}
+        {{ dbt_utils.date_spine(
+            datepart="month",
+            start_date=first_date_adjust,
+            end_date=last_date_adjust
+            )
+        }}
+    {% else %}
+        {{ dbt_utils.date_spine(
+            datepart="month",
+            start_date="'2000-01-01'",
+            end_date="'2000-01-01'"
+            )
+        }}
     {% endif %}
 ),
 general_ledger as (

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -44,12 +44,21 @@ with spine as (
     {% endif %}
     {% endif %}
 
+{% if first_date_adjust!='None' and last_date_adjust!='None' %}
+
     {{ dbt_utils.date_spine(
         datepart="month",
         start_date=first_date_adjust,
         end_date=dbt.dateadd("month", 1, last_date_adjust)
         )
     }}
+{% elif first_date_adjust=='None' %}    
+    {{ dbt_utils.date_spine(
+        datepart="month",
+        start_date=null,
+        end_date=dbt.dateadd("month", 1, last_date_adjust)
+    ) }}
+{% endif %}
 ),
 
 general_ledger as (

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -50,7 +50,7 @@ with spine as (
     {% endif %}
         
     {% if target.type == 'postgres' %}
-        {% if last_date !="null" && last_date != "None" %}
+        {% if last_date !="null" and last_date != "None" %}
             {% set last_date_adjust = "cast('" ~ last_date[0:10] ~ "' as date)" %}
         {% else %}
             {% set last_date_adjust = "cast('2000-01-01' as date)" %}
@@ -62,7 +62,7 @@ with spine as (
     {% endif %}
     {% endif %}
 
-    {% if first_date_adjust !="null" && first_date_adjust!="None" and last_date_adjust !="null" and last_date_adjust!="None" %}
+    {% if first_date_adjust !="null" and first_date_adjust!="None" and last_date_adjust !="null" and last_date_adjust!="None" %}
         {{ dbt_utils.date_spine(
             datepart="month",
             start_date=first_date_adjust,

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -18,10 +18,10 @@ with spine as (
 
         {% endif %}
     {% else %}
-        {% set first_date_adjust = "'2000-01-01'" %}
+        {% set first_date_adjust = "'2001-01-01'" %}
     {% endif %}        
 
-    {% else %} {% set first_date_adjust = "'2000-01-01'" %}
+    {% else %} {% set first_date_adjust = "'2001-01-01'" %}
     {% endif %}
 
     {% if execute %}
@@ -38,14 +38,14 @@ with spine as (
         {% if last_date_result and last_date_result.columns[0][0] %}
             {% set last_date = last_date_result.columns[0][0]|string %}
         {% else %}
-            {% set last_date = "'2000-01-01'" %}
+            {% set last_date = "'2001-01-01'" %}
         {% endif %}
     {% else %}
         {% set last_date_result = run_query(current_date_query) %}
         {% if last_date_result and last_date_result.columns[0][0] %}
             {% set last_date = last_date_result.columns[0][0]|string %}
         {% else %}
-            {% set last_date = "'2000-01-01'" %}
+            {% set last_date = "'2001-01-01'" %}
         {% endif %}
     {% endif %}
         
@@ -53,7 +53,7 @@ with spine as (
         {% if last_date !="null" and last_date != "None" %}
             {% set last_date_adjust = "cast('" ~ last_date[0:10] ~ "' as date)" %}
         {% else %}
-            {% set last_date_adjust = "cast('2000-01-01' as date)" %}
+            {% set last_date_adjust = "cast('2001-01-01' as date)" %}
         {% endif %}
 
     {% else %}
@@ -72,8 +72,8 @@ with spine as (
     {% else %}
         {{ dbt_utils.date_spine(
             datepart="month",
-            start_date="cast('2000-01-01' as date)",
-            end_date="cast('2000-01-01' as date)"
+            start_date="cast('2001-01-01' as date)",
+            end_date="cast('2001-01-01' as date)"
             )
         }}
     {% endif %}

--- a/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
+++ b/models/intermediate/int_quickbooks__general_ledger_date_spine.sql
@@ -44,7 +44,7 @@ with spine as (
     {% endif %}
     {% endif %}
 
-{% if first_date_adjust!='None' and last_date_adjust!='None' %}
+/*{% if first_date_adjust!='None' and last_date_adjust!='None' %}
 
     {{ dbt_utils.date_spine(
         datepart="month",
@@ -58,7 +58,7 @@ with spine as (
         start_date=null,
         end_date=dbt.dateadd("month", 1, last_date_adjust)
     ) }}
-{% endif %}
+{% endif %}*/
 ),
 
 general_ledger as (

--- a/models/quickbooks__general_ledger_by_period.sql
+++ b/models/quickbooks__general_ledger_by_period.sql
@@ -1,4 +1,4 @@
-/*with general_ledger_balances as (
+with general_ledger_balances as (
 
     select *
     from {{ ref('int_quickbooks__general_ledger_balances') }}
@@ -32,7 +32,7 @@ balances_earnings_unioned as (
 
     select *
     from retained_earnings
-), */
+), 
 
 final as (
 

--- a/models/quickbooks__general_ledger_by_period.sql
+++ b/models/quickbooks__general_ledger_by_period.sql
@@ -1,4 +1,4 @@
-with general_ledger_balances as (
+/*with general_ledger_balances as (
 
     select *
     from {{ ref('int_quickbooks__general_ledger_balances') }}
@@ -32,7 +32,7 @@ balances_earnings_unioned as (
 
     select *
     from retained_earnings
-), 
+), */
 
 final as (
 


### PR DESCRIPTION
Yolanda / NoxuData

https://github.com/fivetran/dbt_quickbooks/issues/107

It performs some validation on dates and defaults to a past date if that's invalid, to be able to cast properly.

**How did you validate the changes introduced within this PR?**

I re-ran the transformation on my fivetran system and saw it succeed

**Which warehouse did you use to develop these changes?**

Fivetran

**Did you update the CHANGELOG?**
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.

**PR Template** 
- [Community Pull Request Template](?expand=1&template=pull_request_template.md) (default)

- [Maintainer Pull Request Template](?expand=1&template=maintainer_pull_request_template.md) (to be used by maintainers)
