### PR TITLE
[Prerelease] Add back in Quickstart.yml variables

### DIFF
--- a/.quickstart/quickstart.yml
+++ b/.quickstart/quickstart.yml
@@ -31,15 +31,29 @@ table_variables:
     - bundle_item
     - bundle
     - invoice_line_bundle
+  using_invoice_tax_line:
+    - invoice_tax_line
   using_journal_entry:
     - journal_entry_line
     - journal_entry
+  using_journal_entry_tax_line:
+    - journal_entry_tax_line
   using_payment:
     - payment_line
     - payment
+  using_purchase_tax_line:
+    - purchase_tax_line
   using_refund_receipt:
     - refund_receipt_line
     - refund_receipt
+  using_refund_receipt_tax_line:
+    - refund_receipt_tax_line
+  using_sales_receipt_tax_line:
+    - sales_receipt_tax_line
+  using_tax_agency:
+    - tax_agency
+  using_tax_rate:
+    - tax_rate
   using_transfer:
     - transfer
   using_vendor_credit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_quickbooks v1.0.1-a1
+[PR #179](https://github.com/fivetran/dbt_quickbooks/pull/179) is a pre-release that includes the following updates:
+
+## Quickstart Updates
+- Adds in `quickstart.yml` variables for tax line source tables so Quickstart customers can continue to leverage tax lines based off the latest version of the QuickBooks data models.
+- [Please open a Fivetran support ticket](https://support.fivetran.com/hc/en-us) if you'd like to test out this pre-release and see if the new tax line feature ties out your financial reporting. 
+
 # dbt_quickbooks v1.0.0
 
 [PR #178](https://github.com/fivetran/dbt_quickbooks/pull/178) includes the following updates:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Include the following QuickBooks package version in your `packages.yml` file.
 ```yaml
 packages:
   - package: fivetran/quickbooks
-    version: [">=1.0.0", "<1.1.0"] # we recommend using ranges to capture non-breaking changes automatically
+    version: 1.0.1-a1 # we recommend using ranges to capture non-breaking changes automatically
 ```
 
 > All required sources and staging models are now bundled into this transformation package. Do not include `fivetran/quickbooks_source` in your `packages.yml` since this package has been deprecated.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 name: 'quickbooks'
 
-version: '1.0.0'
+version: '1.0.1'
 
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,6 +1,6 @@
 name: 'quickbooks_integration_tests'
 
-version: '1.0.0'
+version: '1.0.1'
 
 profile: 'integration_tests'
 config-version: 2


### PR DESCRIPTION
Pre-release to add in quickstart.yml variables and [replicate the prior tax line pre-release](https://github.com/fivetran/dbt_quickbooks/releases/tag/v0.22.0-a1).